### PR TITLE
use aom from runtime

### DIFF
--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -579,32 +579,6 @@
       ]
     },
     {
-      "name": "aom",
-      "buildsystem": "cmake-ninja",
-      "builddir": true,
-      "config-opts": [
-        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DBUILD_SHARED_LIBS=ON",
-        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      ],
-      "build-options": {
-        "arch": {
-          "arm": {
-            "config-opts": [
-              "-DAOM_TARGET_CPU=generic"
-            ]
-          }
-        }
-      },
-      "sources": [
-        {
-          "type": "git",
-          "url": "https://aomedia.googlesource.com/aom",
-          "branch": "v1.0.0"
-        }
-      ]
-    },
-    {
       "name": "dav1d",
       "buildsystem": "meson",
       "sources": [


### PR DESCRIPTION
aom is available in runtime for some time already so there shouldn't be need to bundle it with app.