### PR TITLE
Use the new openjpeg shared module

### DIFF
--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -268,23 +268,7 @@
         }
       ]
     },
-    {
-      "name": "openjpeg",
-      "builddir": true,
-      "buildsystem": "cmake-ninja",
-      "config-opts": [
-        "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
-        "-DBUILD_SHARED_LIBS=ON",
-        "-DCMAKE_POSITION_INDEPENDENT_CODE=ON"
-      ],
-      "sources": [
-        {
-          "type": "archive",
-          "url": "https://github.com/uclouvain/openjpeg/archive/v2.3.0.tar.gz",
-          "sha256": "3dc787c1bb6023ba846c2a0d9b1f6e179f1cd255172bde9eb75b01f1e6c7d71a"
-        }
-      ]
-    },
+    "shared-modules/openjpeg/openjpeg.json",
     {
       "name": "gsm",
       "no-autogen": true,

--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -69,7 +69,7 @@
     "shared-modules/SDL/SDL-1.2.15.json",
     "shared-modules/SDL/SDL_image-1.2.12.json",
     "shared-modules/lua5.3/lua-5.3.5.json",
-    "shared-modules/glu/glu-9.0.0.json",
+    "shared-modules/glu/glu-9.json",
     {
       "name": "libraw1394",
       "rm-configure": true,


### PR DESCRIPTION
In addition to the long term benefit of a shared maintenance, this also
brings a couple of immediate wins: the latest release has bug and
security fixes, and the cmake/cleanup config should result in a
slightly faster and smaller build.