### PR TITLE
Remove the use of org.freedesktop.Notification

### DIFF
--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -748,13 +748,14 @@
       "name": "libnotify",
       "buildsystem": "meson",
       "config-opts": [
+        "-Dgtk_doc=false",
         "-Dman=false"
       ],
       "sources": [
         {
           "type": "archive",
-          "url": "https://ftp.gnome.org/pub/GNOME/sources/libnotify/0.8/libnotify-0.8.1.tar.xz",
-          "sha256": "d033e6d4d6ccbf46a436c31628a4b661b36dca1f5d4174fe0173e274f4e62557"
+          "url": "https://download.gnome.org/sources/libnotify/0.8/libnotify-0.8.2.tar.xz",
+          "sha256": "c5f4ed3d1f86e5b118c76415aacb861873ed3e6f0c6b3181b828cf584fc5c616"
         }
       ]
     },

--- a/org.videolan.VLC.json
+++ b/org.videolan.VLC.json
@@ -11,7 +11,6 @@
     "--socket=pulseaudio",
     "--share=network",
     "--filesystem=host",
-    "--talk-name=org.freedesktop.Notifications",
     "--talk-name=org.freedesktop.ScreenSaver",
     "--talk-name=org.freedesktop.secrets",
     "--talk-name=org.kde.kwalletd5",


### PR DESCRIPTION
Starting with 0.8, all calls go through the portal.