### PR TITLE
[Testing] Add libde265 for h264 support

### DIFF
--- a/org.videolan.VLC.yaml
+++ b/org.videolan.VLC.yaml
@@ -629,6 +629,19 @@ modules:
           url-template: https://github.com/protocolbuffers/protobuf/releases/download/v$version/protobuf-cpp-3.$version.tar.gz
     cleanup:
       - /bin
+
+  - name: libde265
+    buildsystem: cmake-ninja
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=None
+      - -DENABLE_SDL=OFF
+    sources:
+      - type: archive
+        url: https://github.com/strukturag/libde265/archive/v1.0.15/libde265-1.0.15.tar.gz
+        sha256: d4e55706dfc5b2c5c9702940b675ce2d3e7511025c6894eaddcdbaf0b15fd3f3
+    cleanup:
+      - /bin
+
   - name: vlc
     config-opts:
       - BUILDCC=/usr/bin/gcc -std=gnu99

--- a/org.videolan.VLC.yaml
+++ b/org.videolan.VLC.yaml
@@ -632,9 +632,6 @@ modules:
 
   - name: libde265
     buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=None
-      - -DENABLE_SDL=OFF
     sources:
       - type: archive
         url: https://github.com/strukturag/libde265/archive/v1.0.15/libde265-1.0.15.tar.gz


### PR DESCRIPTION
Without libde265, VLC could not play some h264 video resulting in the error
`VLC could not decode the format "h264" (H264 - MPEG-4 AVC (part 10))`